### PR TITLE
Removed space from quantity count

### DIFF
--- a/partials/shop-product.htm
+++ b/partials/shop-product.htm
@@ -79,7 +79,7 @@
                 <hr />
                 <div class="form-group">
                   <label class="title" for="customDropdown">Quantity</label>
-                  <input type="text" size="1" value="{{ quantity|default(" 1 ") }}" name="quantity" class="form-control input-sm" />
+                  <input type="text" size="1" value="{{ quantity|default("1") }}" name="quantity" class="form-control input-sm" />
                 </div>
 
                 <div class="stock-level">{{ product.in_stock_amount }} available</div>


### PR DESCRIPTION
Space before and after the "1" here was causing invalid quantity error. 

`<input type="text" size="1" value="{{ quantity|default("1") }}" name="quantity" class="form-control input-sm" />`